### PR TITLE
Fixed optional type issue and freeze playground js version

### DIFF
--- a/pygraphy/static/playground.html
+++ b/pygraphy/static/playground.html
@@ -6,9 +6,9 @@
   <meta charset=utf-8 />
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
-  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
-  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/static/css/index.css" />
+  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/favicon.png" />
+  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/static/js/middleware.js"></script>
 
 </head>
 

--- a/pygraphy/types/base.py
+++ b/pygraphy/types/base.py
@@ -74,8 +74,6 @@ def print_type(gtype, nonnull=True, except_types=()):
 
 
 def load_literal_value(node, ptype):
-    if is_optional(ptype):
-        return load_literal_value(node, ptype.__args__[0])
     if isinstance(node, IntValueNode):
         return int(node.value)
     elif isinstance(node, FloatValueNode):
@@ -97,6 +95,8 @@ def load_literal_value(node, ptype):
             )
         return value
     elif isinstance(node, ObjectValueNode):
+        if is_optional(ptype):
+            return load_literal_value(node, ptype.__args__[0])
         data = {}
         keys = ptype.__dataclass_fields__.keys()
         for field in node.fields:


### PR DESCRIPTION
1. is_optional checking should and should only execute when ObjectValueNode.
2. playground can't fetch introspection correctly because of playground frontend graphql.js version not matched